### PR TITLE
Delete answer using answer uuid

### DIFF
--- a/quora-api/src/main/java/com/upgrad/quora/api/controller/AnswerController.java
+++ b/quora-api/src/main/java/com/upgrad/quora/api/controller/AnswerController.java
@@ -1,9 +1,6 @@
 package com.upgrad.quora.api.controller;
 
-import com.upgrad.quora.api.model.AnswerEditRequest;
-import com.upgrad.quora.api.model.AnswerEditResponse;
-import com.upgrad.quora.api.model.AnswerRequest;
-import com.upgrad.quora.api.model.AnswerResponse;
+import com.upgrad.quora.api.model.*;
 import com.upgrad.quora.service.business.AnswerBusinessService;
 import com.upgrad.quora.service.entity.AnswerEntity;
 import com.upgrad.quora.service.exception.AnswerNotFoundException;
@@ -80,5 +77,26 @@ public class AnswerController {
                 .status("ANSWER EDITED");
         return new ResponseEntity<AnswerEditResponse>(answerEditResponse, HttpStatus.OK);
     }
+
+    /**
+     * Method accepts the answer uuid and authorization token and delete the answer if validation is successful
+     * @param answerId
+     * @param authorization
+     * @return AnswerDeleteResponse JSON
+     * @throws AuthorizationFailedException
+     * @throws AnswerNotFoundException
+     */
+    @RequestMapping(method = RequestMethod.DELETE, path="/answer/delete/{answerId}",
+            produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    public ResponseEntity<AnswerDeleteResponse> deleteAnswer(
+            @PathVariable("answerId") final String answerId, @RequestHeader("authorization") final String authorization)
+        throws AuthorizationFailedException, AnswerNotFoundException{
+            final AnswerEntity deletedAnswerEntity = answerBusinessService.deleteAnswer(answerId, authorization);
+            AnswerDeleteResponse answerDeleteResponse = new AnswerDeleteResponse()
+                    .id(deletedAnswerEntity.getUuid())
+                    .status("ANSWER DELETED");
+            return new ResponseEntity<AnswerDeleteResponse>(answerDeleteResponse, HttpStatus.OK);
+    }
+
 
 }

--- a/quora-service/src/main/java/com/upgrad/quora/service/business/QuestionBusinessService.java
+++ b/quora-service/src/main/java/com/upgrad/quora/service/business/QuestionBusinessService.java
@@ -135,7 +135,7 @@ public class QuestionBusinessService {
                 if(questionEntity == null){
                     throw new InvalidQuestionException("QUES-001","Entered question uuid does not exist");
                 }
-                //if the authorized user is the question owner or his role is administrator, then delete the question
+                //if the authorized user is the question owner or his role is admin, then delete the question
                 if(questionEntity.getUser().getId() == userAuthEntity.getUser().getId() ||
                         userAuthEntity.getUser().getRole().equals("admin")){
                     questionDao.deleteQuestion(questionEntity);

--- a/quora-service/src/main/java/com/upgrad/quora/service/dao/AnswerDao.java
+++ b/quora-service/src/main/java/com/upgrad/quora/service/dao/AnswerDao.java
@@ -45,4 +45,12 @@ public class AnswerDao {
         entityManager.merge(updatedAnswerEntity);
     }
 
+    /**
+     * Method removes the answer entity record from the DB
+     * @param deleteAnswer
+     */
+    public void deleteAnswer(final AnswerEntity deleteAnswer){
+        entityManager.remove(deleteAnswer);
+    }
+
 }


### PR DESCRIPTION
Delete the answer based on the uuid.
Validates if the answers exists and the authorization token provided belongs to answer owner or user with admin role. If authorization successful then delete the answer from DB.
Controller, Service and Dao implemented